### PR TITLE
FIXED Service::formActionOnAjax when action doesn't contain '#'

### DIFF
--- a/src/Service.php
+++ b/src/Service.php
@@ -37,9 +37,7 @@ class Service extends AbstractService
     public function formActionOnAjax(string $formTag)
     {
         if ((defined('DOING_AJAX') && DOING_AJAX) || isset($_POST['gform_ajax'])) {
-            preg_match("/action='(.+)(#[^']+)'/", $formTag, $matches);
-
-            $formTag = str_replace($matches[0], 'action="' . $matches[2] . '"', $formTag);
+            $formTag = preg_replace("/action='(.+)(#[^']+)'/", 'action="$2"', $formTag);
         }
 
         return $formTag;


### PR DESCRIPTION
It's based on Sentry error
```
Notice: Undefined offset: 0
```
The value of `$formTag` was
```
<form method='post' enctype='multipart/form-data' target='gform_ajax_frame_4' id='gform_4'  action='/bourse/analystes-boursiers/eric-ludwig/page/2/' novalidate>
```